### PR TITLE
Feature/release improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.log
 *.pyc
 **/*.pyc
-
+**/.ropeproject
 # sbt specific
 dist/*
 target/
@@ -13,7 +13,7 @@ project/plugins/project/
 .DS_Store
 # Scala-IDE specific
 .scala_dependencies
-
+tags
 .idea/
 release.iml
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ This repo provides a script that allows to tag a git repository:
 }
 ```
 
-  - Replace <username> with your jenkins username.
-  - Replace <api-token> with the value obtained from Jenkins.
-  - Configure github and jenkins urls to the appropriate values.
+Replace ```<username>``` with your jenkins username.
+Replace ```<api-token>``` with the value obtained from Jenkins.
+Configure github and jenkins urls to the appropriate values.
 
 * In addition to that you need some python libraries: requests, pymongo and bottle. 
 ```

--- a/README.md
+++ b/README.md
@@ -8,13 +8,20 @@ This repo provides a script that allows to tag a git repository:
 
 ##Prepare the environment
 
-* To enable scripts to interact with jenkins, define a 'jenkins_key' and 'jenkins_user' environment variable in your bashrc file. 
+* Set up your local configuration by creating a file ```~/.hmrc/release.conf``` which is a json formatted file that should look like this:
+
 ```
-export jenkins_user=<username>
-export jenkins_key=<api-token>
+{
+    "git":"git@<your_git-instance:your_repo>",
+    "jenkins":"https://<your-jenkins>",
+    "jenkins_user": "<username>",
+    "jenkins_key": "<api-token>"
+}
 ```
-Replace <username> with your jenkins username (no quotes)
-Replace <api-token> with the value obtained from Jenkins
+
+  - Replace <username> with your jenkins username.
+  - Replace <api-token> with the value obtained from Jenkins.
+  - Configure github and jenkins urls to the appropriate values.
 
 * In addition to that you need some python libraries: requests, pymongo and bottle. 
 ```
@@ -25,7 +32,6 @@ $ sudo pip install requests
 $ sudo pip install pymongo
 $ sudo pip install bottle
 ```
-* Configure github and jenkins urls in src/universal/conf/hosts.json
 
 ## Release
 * Tag the artefact: ```python release.py -v jenkins_job_name build_number```

--- a/src/universal/bin/git.py
+++ b/src/universal/bin/git.py
@@ -1,18 +1,18 @@
 #
 #  Copyright 2015 HM Revenue & Customs
-# 
+#
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#  
+#
 #!/usr/bin/env python
 
 import os
@@ -52,10 +52,10 @@ class Git:
         lib.call_and_exit_if_failed('git checkout -q ' + branch)
         lib.call_and_exit_if_failed('git pull -q origin ' + branch)
 
-    def describe(self):
+    def describe(self, ref):
         path = self.path()
         os.chdir(path)
-        tag_query = lib.call('git describe --abbrev=0 --match release/*')
+        tag_query = lib.call('git describe --abbrev=0 --match release/* %s' % ref)
         last_tag = "0.0.0"
         if tag_query.returncode == 0:
             last_tag = tag_query.stdout.read().strip()

--- a/src/universal/bin/jenkins.py
+++ b/src/universal/bin/jenkins.py
@@ -36,7 +36,7 @@ class Jenkins:
 
     jenkins_git_hub_url_property_name = "scm/userRemoteConfigs/hudson.plugins.git.UserRemoteConfig/url"
 
-    def __init__(self, host, user=os.environ["jenkins_user"], key=os.environ["jenkins_key"]):
+    def __init__(self, host, user, key):
         self.host = host
         self.auth = (user, key)
 

--- a/src/universal/bin/jenkins.py
+++ b/src/universal/bin/jenkins.py
@@ -1,18 +1,18 @@
 #
 #  Copyright 2015 HM Revenue & Customs
-# 
+#
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#  
+#
 
 import os
 import ast
@@ -22,9 +22,10 @@ import xml.etree.ElementTree as ET
 
 def find_commit_id(jenkins_job_info):
     json = ast.literal_eval(jenkins_job_info)
-    return [obj["lastBuiltRevision"]['SHA1'] for obj in json['actions'] if
-            (obj.get("buildsByBranchName"))].pop()
+    out = [obj["lastBuiltRevision"]['SHA1'] for obj in json['actions'] if
+            (obj.get("buildsByBranchName"))]
 
+    return out.pop()
 
 def is_build_green(jenkins_job_info):
     json = ast.literal_eval(jenkins_job_info)

--- a/src/universal/bin/release.py
+++ b/src/universal/bin/release.py
@@ -1,18 +1,18 @@
-#
+#!/usr/bin/env python
 #  Copyright 2015 HM Revenue & Customs
-# 
+#
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#  
+#
 
 import argparse
 import os
@@ -31,10 +31,27 @@ parser.add_argument('buildNumber', type=str, help='The jenkins build number we w
 args = parser.parse_args()
 
 WORKSPACE = expanduser("~/.release")
+RELEASE_CONF=os.path.expanduser("~/.hmrc_release_conf.json")
 
 if os.path.exists(WORKSPACE):
     shutil.rmtree(WORKSPACE)
 os.mkdir(WORKSPACE)
+
+#def release_config():
+#    out = {}
+#    if os.path.exists(RELEASE_CONF):
+#        try:
+#            out.update(json.loads(RELEASE_CONF))
+#        except RuntimeError, ex:
+#            print("Config file %s is probably not valid JSON: %s" % (RELEASE_CONF, ex.msg))
+#
+#    else:
+#        try:
+#            hosts_json = lib.open_as_json('conf/hosts.json')
+#            out.update(json.loads(RELEASE_CONF))
+#        except RuntimeError, ex:
+#            print("Config file %s is probably not valid JSON: %s" % (RELEASE_CONF, ex.msg)
+
 
 hosts_json = lib.open_as_json('conf/hosts.json')
 jenkins = Jenkins(hosts_json['jenkins'])
@@ -42,7 +59,7 @@ jenkins = Jenkins(hosts_json['jenkins'])
 
 def verbose(message):
     if args.verbose:
-        print message
+        print(message)
 
 
 def run():
@@ -50,7 +67,7 @@ def run():
     jenkins_build_number = args.buildNumber
 
     if not jenkins.find_if_build_is_green(jenkins_project, jenkins_build_number):
-        print "Build #" + jenkins_build_number + " of '" + jenkins_project + "' is not a green build."
+        print("Build #" + jenkins_build_number + " of '" + jenkins_project + "' is not a green build.")
         sys.exit(1)
 
     repo_url = jenkins.find_github_repo_url_from_build(jenkins_project)
@@ -66,7 +83,7 @@ def run():
     git.clone()
     verbose("Git repo '" + repo_name + "' cloned to " + WORKSPACE)
 
-    most_recent_tag = git.describe()
+    most_recent_tag = git.describe(commit_id)
     verbose("Most recent release: " + most_recent_tag)
 
     new_version_number = lib.read_user_preferred_version(repo_name, most_recent_tag)

--- a/src/universal/conf/hosts.json
+++ b/src/universal/conf/hosts.json
@@ -1,4 +1,5 @@
 {
-    "jenkins":"https://ci.example.com",
-    "git":"git@github.com:yourOrg"
+    "jenkins":"https://ci-dev.tax.service.gov.uk",
+    "nexus":"https://nexus-dev.tax.service.gov.uk",
+    "git":"git@github.tools.tax.service.gov.uk:hmrc"
 }


### PR DESCRIPTION
This incorporates a bug fix and a configuration improvement.

1. Multiple bugfix releases could not be released from a branch. The code now does the "git describe" relative to the git commit that was built by jenkins.
2. Config is gathered from env variables (creds) and the conf/hosts.json file (urls). I have added in functionality to also look in ~/.hmrc/release.conf for all of that config, and falls back to the previous functionality if it cannot be found.