### PR TITLE
Tests around configuration modifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 *.log
 *.pyc
 **/*.pyc
-
+**/.ropeproject
 # sbt specific
 dist/*
 target/
@@ -13,7 +13,7 @@ project/plugins/project/
 .DS_Store
 # Scala-IDE specific
 .scala_dependencies
-
+tags
 .idea/
 release.iml
 

--- a/README.md
+++ b/README.md
@@ -8,13 +8,20 @@ This repo provides a script that allows to tag a git repository:
 
 ##Prepare the environment
 
-* To enable scripts to interact with jenkins, define a 'jenkins_key' and 'jenkins_user' environment variable in your bashrc file. 
+* Set up your local configuration by creating a file ```~/.hmrc/release.conf``` which is a json formatted file that should look like this:
+
 ```
-export jenkins_user=<username>
-export jenkins_key=<api-token>
+{
+    "git":"git@<your_git-instance:your_repo>",
+    "jenkins":"https://<your-jenkins>",
+    "jenkins_user": "<username>",
+    "jenkins_key": "<api-token>"
+}
 ```
-Replace <username> with your jenkins username (no quotes)
-Replace <api-token> with the value obtained from Jenkins
+
+Replace ```<username>``` with your jenkins username.
+Replace ```<api-token>``` with the value obtained from Jenkins.
+Configure github and jenkins urls to the appropriate values.
 
 * In addition to that you need some python libraries: requests, pymongo and bottle. 
 ```
@@ -25,7 +32,6 @@ $ sudo pip install requests
 $ sudo pip install pymongo
 $ sudo pip install bottle
 ```
-* Configure github and jenkins urls in src/universal/conf/hosts.json
 
 ## Release
 * Tag the artefact: ```python release.py -v jenkins_job_name build_number```

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-cd test
-python -m unittest discover
+python -m unittest discover test $*

--- a/src/universal/bin/config.py
+++ b/src/universal/bin/config.py
@@ -1,0 +1,41 @@
+import argparse
+import os
+import json
+import lib
+import sys
+from os.path import expanduser
+
+
+class Configuration:
+    def __init__(self, config_file_path="~/.hmrc/release.conf", env=os.environ):
+        legacy_hosts_file = 'conf/hosts.json'
+        self.config_file = expanduser(config_file_path)
+        out = {}
+        try:
+            hosts_json = lib.open_as_json(legacy_hosts_file)
+            out.update(hosts_json)
+        except RuntimeError, ex:
+            print("Config file %s is probably not valid JSON: %s" % (legacy_hosts_file, ex.msg))
+
+        if os.path.exists(self.config_file):
+            try:
+                out.update(json.load(open(self.config_file)))
+            except RuntimeError, ex:
+                print("Config file %s is probably not valid JSON: %s" % (self.config_file, ex.msg))
+
+        if (not out.has_key('jenkins_user')):
+            out['jenkins_user'] = env.get("jenkins_user", None)
+        if (not out.has_key('jenkins_key')):
+            out['jenkins_key'] = env.get("jenkins_key", None)
+
+        self.__dict__.update(out)
+
+    def validate(self):
+        expected = ["jenkins", "jenkins_user", "jenkins_key"]
+        out = [key for key in expected if not self.__dict__[key]]
+        if out:
+            print "Warning: The following keys need adding to your JSON config file %s." % out
+            sys.exit(1)
+
+
+

--- a/src/universal/bin/git.py
+++ b/src/universal/bin/git.py
@@ -1,18 +1,18 @@
 #
 #  Copyright 2015 HM Revenue & Customs
-# 
+#
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#  
+#
 #!/usr/bin/env python
 
 import os
@@ -52,10 +52,10 @@ class Git:
         lib.call_and_exit_if_failed('git checkout -q ' + branch)
         lib.call_and_exit_if_failed('git pull -q origin ' + branch)
 
-    def describe(self):
+    def describe(self, ref=''):
         path = self.path()
         os.chdir(path)
-        tag_query = lib.call('git describe --abbrev=0 --match release/*')
+        tag_query = lib.call('git describe --abbrev=0 --match release/* %s' % ref)
         last_tag = "0.0.0"
         if tag_query.returncode == 0:
             last_tag = tag_query.stdout.read().strip()

--- a/src/universal/bin/jenkins.py
+++ b/src/universal/bin/jenkins.py
@@ -1,18 +1,18 @@
 #
 #  Copyright 2015 HM Revenue & Customs
-# 
+#
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#  
+#
 
 import os
 import ast
@@ -22,9 +22,10 @@ import xml.etree.ElementTree as ET
 
 def find_commit_id(jenkins_job_info):
     json = ast.literal_eval(jenkins_job_info)
-    return [obj["lastBuiltRevision"]['SHA1'] for obj in json['actions'] if
-            (obj.get("buildsByBranchName"))].pop()
+    out = [obj["lastBuiltRevision"]['SHA1'] for obj in json['actions'] if
+            (obj.get("buildsByBranchName"))]
 
+    return out.pop()
 
 def is_build_green(jenkins_job_info):
     json = ast.literal_eval(jenkins_job_info)
@@ -35,7 +36,7 @@ class Jenkins:
 
     jenkins_git_hub_url_property_name = "scm/userRemoteConfigs/hudson.plugins.git.UserRemoteConfig/url"
 
-    def __init__(self, host, user=os.environ["jenkins_user"], key=os.environ["jenkins_key"]):
+    def __init__(self, host, user, key):
         self.host = host
         self.auth = (user, key)
 

--- a/src/universal/bin/lib.py
+++ b/src/universal/bin/lib.py
@@ -1,18 +1,18 @@
 #
 #  Copyright 2015 HM Revenue & Customs
-# 
+#
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
 #  You may obtain a copy of the License at
-# 
+#
 #    http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 #  Unless required by applicable law or agreed to in writing, software
 #  distributed under the License is distributed on an "AS IS" BASIS,
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-#  
+#
 #!/usr/bin/env python
 
 import subprocess
@@ -23,7 +23,9 @@ import sys
 
 
 def open_as_json(source):
-    with open(os.path.join(os.path.dirname(os.path.realpath(__file__)), os.pardir, source)) as f:
+    this_file = os.path.realpath(__file__)
+    path = os.path.join(os.path.dirname(this_file), os.pardir, source)
+    with open(path) as f:
         return json.load(f)
 
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,0 +1,100 @@
+import sys
+import os
+this_file = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(this_file, "../src/universal/bin"))
+import lib
+import json
+import shutil
+import unittest
+
+from config import Configuration
+
+class ConfigTestCase(unittest.TestCase):
+    def setUp(self):
+        self.conf_1 = "/tmp/release_config_test_file_1.config"
+
+        with open(self.conf_1, "w") as fh:
+            json.dump({}, fh)
+
+        self.conf_2 = "/tmp/release_config_test_file_2.config"
+
+        with open(self.conf_2, "w") as fh:
+            json.dump({'jenkins_user': 'brian'}, fh)
+
+        self.conf_3 = "/tmp/release_config_test_file_3.config"
+
+        with open(self.conf_3, "w") as fh:
+            json.dump({'jenkins_user': 'brian', 'jenkins_key': '987fed', 'jenkins': 'http://my-real-jenkins.com'}, fh)
+
+    def tearDown(self):
+        map(lambda x: os.remove(x), [
+            self.conf_1, self.conf_2, self.conf_3
+        ])
+
+    def test_no_config_file_no_env_var(self):
+        config = Configuration("~/no_such_file", {})
+
+        jenkins = config.jenkins
+        jenkins_user = config.jenkins_user
+        jenkins_key = config.jenkins_key
+
+        self.assertTrue(jenkins_user == None)
+        self.assertTrue(jenkins_key == None)
+        self.assertTrue(jenkins == 'https://ci.example.com')
+
+    def test_empty_config_file_no_env_var(self):
+        config = Configuration(self.conf_1, {})
+
+        jenkins = config.jenkins
+        jenkins_user = config.jenkins_user
+        jenkins_key = config.jenkins_key
+
+        self.assertTrue(jenkins_user == None)
+        self.assertTrue(jenkins_key == None)
+        self.assertTrue(jenkins == 'https://ci.example.com')
+
+    def test_no_config_file_with_env_var(self):
+        config = Configuration('nothing_to_see', {'jenkins_user': 'bob'})
+
+        jenkins = config.jenkins
+        jenkins_user = config.jenkins_user
+        jenkins_key = config.jenkins_key
+
+        self.assertTrue(jenkins_user == 'bob')
+        self.assertTrue(jenkins_key == None)
+        self.assertTrue(jenkins == 'https://ci.example.com')
+
+    def test_empty_config_file_with_env_var(self):
+        config = Configuration(self.conf_1, {'jenkins_user': 'bob'})
+
+        jenkins = config.jenkins
+        jenkins_user = config.jenkins_user
+        jenkins_key = config.jenkins_key
+
+        self.assertTrue(jenkins_user == 'bob')
+        self.assertTrue(jenkins_key == None)
+        self.assertTrue(jenkins == 'https://ci.example.com')
+
+    def test_config_file_overrides_env_var(self):
+        config = Configuration(self.conf_2, {'jenkins_user': 'bob'})
+
+        jenkins = config.jenkins
+        jenkins_user = config.jenkins_user
+        jenkins_key = config.jenkins_key
+
+        self.assertTrue(jenkins_user == 'brian')
+        self.assertTrue(jenkins_key == None)
+        self.assertTrue(jenkins == 'https://ci.example.com')
+
+
+    def test_config_file_overrides_everything(self):
+        config = Configuration(self.conf_3, {'jenkins_user': 'bob', 'jenkins_key': 'abc123'})
+
+        jenkins = config.jenkins
+        jenkins_user = config.jenkins_user
+        jenkins_key = config.jenkins_key
+
+        self.assertTrue(jenkins_user == 'brian')
+        self.assertTrue(jenkins_key == '987fed')
+        self.assertTrue(jenkins == 'http://my-real-jenkins.com')
+

--- a/test/test_git.py
+++ b/test/test_git.py
@@ -1,6 +1,7 @@
 import sys
-sys.path.append("../src/universal/bin")
 import os
+this_file = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(this_file, "../src/universal/bin"))
 import lib
 import shutil
 import unittest

--- a/test/test_jenkins.py
+++ b/test/test_jenkins.py
@@ -1,6 +1,8 @@
 import sys
+import os
+this_file = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(this_file, "../src/universal/bin"))
 
-sys.path.append("../src/universal/bin")
 import unittest
 from jenkins import find_commit_id, is_build_green
 

--- a/test/test_lib.py
+++ b/test/test_lib.py
@@ -1,5 +1,6 @@
-import sys
-sys.path.append("../src/universal/bin")
+import sys, os
+this_file = os.path.dirname(os.path.realpath(__file__))
+sys.path.append(os.path.join(this_file, "../src/universal/bin"))
 import unittest
 from lib import call, read_user_preferred_version_with_input_function
 


### PR DESCRIPTION
More tests added around backward compatibility. Backward compatibility now more tolerant to partial configuration and no longer requires the ~/.hmrc/release.conf file.

Note: The release script no longer needs to be run from the release repo, it can be called from anywhere (and hence symlinked into /usr/bin or the src/universal/bin dir added to your path etc.)